### PR TITLE
rebar3 support for jamdb_oracle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ deps
 *.plt
 erl_crash.dump
 ebin
+_build/
 rel/example_project
 .concrete/DEV_MODE
 .rebar
+rebar.lock

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,3 @@
+{deps, [
+	{jose, ".*", {git, "https://github.com/potatosalad/erlang-jose.git", {tag, "1.4.2"}}}
+]}.


### PR DESCRIPTION
Unfortunately, rebar3 doesnt support erlang.mk format, thats why adding rebar.config will be fine for proper usage in rebar3 environment.