### PR TITLE
Add support for service name

### DIFF
--- a/src/jamdb_oracle_conn.erl
+++ b/src/jamdb_oracle_conn.erl
@@ -23,12 +23,13 @@
 -type procedure_result() :: {proc_result, return_status(), out_params() | metainfo()}.
 -type result() :: affected_rows() | result_set() | procedure_result().
 -type query_result() :: {ok, [result()], state()}.
--type env() :: 
+-type env() ::
         {host, string()} |
         {port, non_neg_integer()} |
         {user, string()} |
         {password, string()} |
         {sid, string()} |
+        {service_name, string()} |
         {app_name, string()}.
 -type options() :: [env()].
 


### PR DESCRIPTION
Where I work, we connect using service name, not sid. These changes
allow either way of connecting to work.

It also separates out the generation of the tns string from its
encoding. These seem like seperate concerns. For example, I worked
with @cdinger on the tns redirect response and we would like to be
able to use the redirect tns string directly.

Any feedback you have would be appreciated. Thanks