### PR TITLE
Use config file for connection info in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rel/example_project
 .concrete/DEV_MODE
 .rebar
 rebar.lock
+test/test.config

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Getting Started
 
 ```
 
+Running Tests
+======
+First, save `test/test.config.example` as `test/test.config` and supply
+connection details for your test database. Once the connection configuration
+is saved, run the test suite with `rebar3 ct`.
+
+
 Author
 ======
 Mykhailo Vstavskyi

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {deps, [
-	{jose, ".*", {git, "https://github.com/potatosalad/erlang-jose.git", {tag, "1.4.2"}}}
+	{jose, ".*", {git, "https://github.com/potatosalad/erlang-jose.git", {tag, "1.8.0"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
 {deps, [
 	{jose, ".*", {git, "https://github.com/potatosalad/erlang-jose.git", {tag, "1.8.0"}}}
 ]}.
+{ct_opts, [{config, "test/test.config"}]}.

--- a/test/jamdb_oracle_SUITE.erl
+++ b/test/jamdb_oracle_SUITE.erl
@@ -4,15 +4,6 @@
 
 -compile(export_all).
 
--define(ConnOpts, [
-	{host, "jamdb-oracle-dev.erlangbureau.dp.ua"},
-	{port, 1521},
-	{user, "jamdbtest"},
-	{password, "jamdbtest"},
-	{sid, "JAMDBTEST"},
-	{app_name, "jamdbtest"}
-]).
-
 %% Common Test callbacks
 
 all() ->
@@ -69,7 +60,7 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    {ok, ConnRef} = jamdb_oracle:start(?ConnOpts),
+    {ok, ConnRef} = jamdb_oracle:start(ct:get_config(connection_options)),
     [{conn_ref, ConnRef}|Config].
 
 end_per_suite(Config) ->

--- a/test/jamdb_oracle_test.erl
+++ b/test/jamdb_oracle_test.erl
@@ -2,21 +2,12 @@
 
 -compile(export_all).
 
--define(ConnOpts, [
-	{host, "jamdb-oracle-dev.erlangbureau.dp.ua"},
-	{port, 1521},
-	{user, "jamdbtest"},
-	{password, "jamdbtest"},
-	{sid, "JAMDBTEST"},
-	{app_name, "jamdbtest"}
-]).
-
 -define(query(ConnRef,Query), jamdb_oracle:sql_query(ConnRef,Query)).
 
 %% Test callbacks
 
 all() ->
-    {ok, ConnRef} = jamdb_oracle:start(?ConnOpts),
+    {ok, ConnRef} = jamdb_oracle:start(ct:get_config(connection_options)),
     
     {ok, [{affected_rows,0}]} = 
     ?query(ConnRef, "create table t_number ( C_NUMBER NUMBER )"),

--- a/test/test.config.example
+++ b/test/test.config.example
@@ -1,0 +1,8 @@
+% Copy this file to test/test.config and modify as needed.
+{connection_options, [{host, "somehost.com"},
+                      {port, 1521},
+                      {user, "someuser"},
+                      {password, "somepassword"},
+                      {service_name, "someservicename"},
+                      % {sid, "or_sid"},
+                      {app_name, "someappname"}]}.


### PR DESCRIPTION
This PR moves the database connection details to a configuration file to accommodate non-erlangbureau developers. An example `test/tests.config.example` file has been added to show the expected structure. Instructions for running tests have also been added to README.md

The instructions in README expect that developers are using rebar to run tests. Not being an erlang developer, I'm not sure how common it is to use `rebar ct` vs `ct_run`. I've assumed that most developers are using rebar3. If this is not the case, feedback is welcome!