### PR TITLE
Fix Clob (for oracle 12?)

### DIFF
--- a/src/jamdb_oracle_tns_decoder.erl
+++ b/src/jamdb_oracle_tns_decoder.erl
@@ -604,10 +604,20 @@ decode_rowid(Data,Count,Acc) ->
 
 decode_clob(Data) ->
     Rest2 = decode_next(ub4,Data,3),
-    Rest3 = decode_next(ub1,Rest2,2),
-    Value = decode_chr(Rest3),
-    Rest4 = decode_next(chr,Rest3),
-    {Value, decode_next(Rest4)}.
+    Rest3 = decode_next(ub1,Rest2),
+    Rest4 = decode_next(ub4,Rest3),
+    Rest5 = decode_next(ub1,Rest4),
+    PreValue = decode_chr(Rest5),
+    Value = decode_utf8(PreValue),
+    Rest = decode_next(chr,Rest5),
+    {Value, decode_next(Rest)}.
+
+decode_utf8(Data) ->
+  decode_utf8(Data, []).
+decode_utf8([], Acc) ->
+  lists:reverse(Acc);
+decode_utf8([Octets, Char | Rest], Acc) ->
+  decode_utf8(Rest, [ (Octets * 256) + Char | Acc ]).
 
 decode_blob(Data) ->
     Rest2 = decode_next(ub4,Data,3),


### PR DESCRIPTION
In oracle 12, the clob packets I am getting are something like this
(with added new lines to expose part of the structure):

<<
  1,86,1,15,2,31,124,1,2,7,208,1,
  30,
  0,83,0,116,0,117,0,100,0,101,0,110,0,116,0,115,0,32,0,
  105,0,110,0,32,0,67,0,76,0,65,
... more ...
>>

The 13th byte - 30 - is a length, followed by the text of the clob: 0,83,0,116,0,117,0,100,0,101,0,110,0,116,0,115,0,32,0,105,0,110,
0,32,0,67,0,76,0,65 .

It looks like the existing decode_clob was not skipping over enough
of the header, so byte 10 was getting interpreted as the length,
splitting the packet around byte 18 (in this case), and byte 19 (117) was getting fed into decode_token/2 and raising an error.

The characters are encoded as 2-element base256 representations
of utf8 characters; the interspersed 0s in the above examples are
because this particular clob's characters all have a codepoint < 256
decimal. If there had been a character such as ł (322) it would have
been represented as [1, 66] ( = (256 * 1) + 66 = 322).