### PR TITLE
fix: Handles missing clause

### DIFF
--- a/lib/jamdb_oracle.ex
+++ b/lib/jamdb_oracle.ex
@@ -214,6 +214,7 @@ defmodule Jamdb.Oracle do
     case query(s, 'PING') do
       {:ok, _} -> {:ok, s}
       {:error, err} -> {:disconnect, error!(err), s}
+      {:disconnect, reason} -> {:disconnect, error!(reason), s}
     end
   end
   def ping(%{mode: :transaction} = s) do


### PR DESCRIPTION
We saw this exception in our code:

```
GenServer #PID<0.3152.0> terminating
** (CaseClauseError) no case clause matching: {:disconnect, :closed}
    (jamdb_oracle) lib/jamdb_oracle.ex:215: Jamdb.Oracle.ping/1
    (db_connection) lib/db_connection/connection.ex:154: DBConnection.Connection.handle_cast/2
    (connection) lib/connection.ex:810: Connection.handle_async/3
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:259: :proc_lib.wake_up/3
Last message: {:"$gen_cast", {:ping, #Reference<0.523115769.510787587.38186>, %Jamdb.Oracle{cursors: nil, mode: :idle, pid: #PID<0.3153.0>}}}
State: {Jamdb.Oracle, %Jamdb.Oracle{cursors: nil, mode: :idle, pid: #PID<0.3153.0>}}
```

I figured this was the fix that was missing.