### PR TITLE
fix: Handles errors on tcp socket connection

### DIFF
--- a/src/jamdb_oracle.erl
+++ b/src/jamdb_oracle.erl
@@ -44,7 +44,11 @@ init(Opts) ->
                 _ -> {ok, State}
             end;
         {ok, Result, _State} ->
-            {stop, Result}
+            {stop, Result};
+        {error, ErrorType, Reason} ->
+            {stop, {ErrorType, Reason}};
+        {error, ErrorType, Reason, _State} ->
+            {stop, {ErrorType, Reason}}
     end.
 
 %% Error types: socket, remote, local

--- a/src/jamdb_oracle_conn.erl
+++ b/src/jamdb_oracle_conn.erl
@@ -15,7 +15,7 @@
 -type rows() :: list().  %% TODO
 -type return_status() :: non_neg_integer().
 -type out_params() :: list().  %% TODO
--type empty_result() :: {ok, state()} | {error, error_type(), binary(), state()}.
+-type empty_result() :: {ok, state()} | {error, error_type(), term()} | {error, error_type(), binary(), state()}.
 -type fetched_rows() :: {fetched_rows, non_neg_integer(), metainfo(), rows()}.
 -type affected_rows() :: {affected_rows, non_neg_integer()}.
 -type result_set() :: {result_set, columns(), metainfo(), rows()}.
@@ -151,7 +151,7 @@ handle_token(<<Token, Data/binary>>, State) ->
 	?TTI_RPA ->
             case ?DECODER:decode_token(rpa, Data) of
                 {?TTI_SESS, Request} ->
-		    send_req(auth, State#oraclient{req=Request});
+                  send_req(auth, State#oraclient{req=Request});
                 {?TTI_AUTH, Resp, Ver, SessId} ->
                     #oraclient{auth = KeyConn} = State,
                     Cursors = spawn(fun() -> loop([]) end),


### PR DESCRIPTION
We got the following error on Friday, so I added a basic implementation around handling that error.

```
Jamdb.Oracle (#PID<0.4115.0>) failed to connect: ** (DBConnection.ConnectionError) {{:case_clause, {:error, :socket, :timeout}}, [{:jamdb_oracle, :init, 1, [file: 'src/jamdb_oracle.erl', line: 40]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 374]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 342]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}
```