### PR TITLE
guard receive functions

### DIFF
--- a/src/jamdb_oracle_conn.erl
+++ b/src/jamdb_oracle_conn.erl
@@ -331,7 +331,7 @@ get_result(_Type, _RetCode, _RowNumber, _RowFormat, _Rows) ->
     more.
 
 get_result(undefined) -> [];
-get_result(Cursors) when is_pid(Cursors) -> Cursors ! {get, self()}, receive Reply -> Reply end;
+get_result(Cursors) when is_pid(Cursors) -> Cursors ! {get, self()}, receive Reply when is_list(Reply) -> Reply end;
 get_result(#format{column_name=Column}) -> Column.
 
 freeval(undefined) -> true;
@@ -348,7 +348,7 @@ currval(DefCol, _Result, _Cursors) -> {more, DefCol}.
 
 nextval(Task) when is_pid(Task) ->
     Task ! {get, self()},
-    Tseq = receive 127 -> 0; Reply -> Reply end,
+    Tseq = receive 127 -> 0; Reply when is_integer(Reply) -> Reply end,
     Task ! {set, Tseq + 1}, Tseq + 1;
 nextval(Tseq) -> Tseq.
 


### PR DESCRIPTION
We observed in #178 that unexpected messages could cause function_clause errors. By guarding on the expected types we gain some guarantees about the message contents

I'm certainly a novice in erlang. This may not be the right way to resolve this issue. Though, it does appear to fix it for the reproduction we created in #178.

Some thoughts.

* This does not read the message and remove it from the queue. This could lead to messages piling up.
* There are other `receive` calls that I didn't guard. I can try to drive out a case where these occur. However, I wanted to see if this approach makes sense before spending more time on this.