### PR TITLE
Elixir 17 fixes for charlist sigils

### DIFF
--- a/lib/jamdb_oracle.ex
+++ b/lib/jamdb_oracle.ex
@@ -233,7 +233,7 @@ defmodule Jamdb.Oracle do
 
   @impl true
   def checkout(%{pid: pid, timeout: timeout} = s) do
-    case sql_query(pid, 'SESSION', timeout) do
+    case sql_query(pid, ~c'SESSION', timeout) do
       {:ok, _} -> {:ok, s}
       {:error, err} -> {:disconnect, error!(err), s}
     end
@@ -241,7 +241,7 @@ defmodule Jamdb.Oracle do
 
   @impl true
   def ping(%{pid: pid, timeout: timeout, idle_interval: idle_interval} = s) do
-    case sql_query(pid, 'PING', min(timeout, idle_interval)) do
+    case sql_query(pid, ~c'PING', min(timeout, idle_interval)) do
       {:ok, _} -> {:ok, s}
       {:error, err} -> {:disconnect, error!(err), s}
     end

--- a/lib/jamdb_oracle_sql.ex
+++ b/lib/jamdb_oracle_sql.ex
@@ -304,14 +304,14 @@ defmodule Jamdb.Oracle.SQL do
   end
 
   defp unique_constraint?(err) do
-    match_or_nil(~r/'ORA-00001: unique constraint \((.*)\) violated\\n'/, err.message, fn name ->
+    match_or_nil(~r/ORA-00001: unique constraint \((.*)\) violated/, err.message, fn name ->
       [unique: name]
     end)
   end
 
   defp integrity_child_constraint?(err) do
     match_or_nil(
-      ~r/'ORA-02292: integrity constraint \((.*)\) violated - child record found\\n'/,
+      ~r/ORA-02292: integrity constraint \((.*)\) violated - child record found/,
       err.message,
       fn name -> [foreign_key: name] end
     )
@@ -319,14 +319,14 @@ defmodule Jamdb.Oracle.SQL do
 
   defp integrity_parent_constraint?(err) do
     match_or_nil(
-      ~r/'ORA-02291: integrity constraint \((.*)\) violated - parent key not found\\n'/,
+      ~r/ORA-02291: integrity constraint \((.*)\) violated - parent key not found/,
       err.message,
       fn name -> [foreign_key: name] end
     )
   end
 
   defp check_constraint?(err) do
-    match_or_nil(~r/'ORA-02290: check constraint \((.*)\) violated\\n'/, err.message, fn name ->
+    match_or_nil(~r/ORA-02290: check constraint \((.*)\) violated/, err.message, fn name ->
       [check: name]
     end)
   end


### PR DESCRIPTION
Elixir 1.17 formats charlists with sigil_c. The connection error that is returned when encountering constraint errors seems to inspect the charlist, so the string is formatted as `"~c\"ORA-ERR: message\""`. Because of this, `unique_constraint` was not respected in Elixir 1.17 because the constraints errors messages could not be matched.

In addition, I fixed some deprecation warnings about creating charlists without `sigil_c`. That sigil was introduced in Elixir 1.9, so it should not be a breaking change based on the versions that this library declares it supports.